### PR TITLE
Support no extention file and directory

### DIFF
--- a/src/watchtower/core.clj
+++ b/src/watchtower/core.clj
@@ -103,5 +103,6 @@
   (let [exts-set (set (map name exts))]
     (fn [f]
       (let [fname (.getName f)
-            cur (subs fname (inc (.lastIndexOf fname ".")))]
+            idx (.lastIndexOf fname ".")
+            cur (if-not (neg? idx) (subs fname (inc idx)))]
         (exts-set cur)))))


### PR DESCRIPTION
In noir-cljs, I cannnot work with "cljs" directory bacause directory named "cljs" is filtered by watchtower.
So I fix "extention" function to check whether file has extention or not.
