### PR TITLE
Add change-first? function

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject
-  uochan/watchtower "0.1.3"
+  uochan/watchtower "0.1.4"
   :description "A library for directory watchers forked by ibdknox/watchtower"
   :dependencies [[org.clojure/clojure "1.4.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject
-  uochan/watchtower "0.1.2"
+  uochan/watchtower "0.1.3"
   :description "A library for directory watchers forked by ibdknox/watchtower"
-  :dependencies [[org.clojure/clojure "1.3.0"]])
+  :dependencies [[org.clojure/clojure "1.4.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,4 @@
-(defproject watchtower "0.1.1"
-  :description "A library for directory watchers"
+(defproject
+  uochan/watchtower "0.1.2"
+  :description "A library for directory watchers forked by ibdknox/watchtower"
   :dependencies [[org.clojure/clojure "1.3.0"]])

--- a/src/watchtower/core.clj
+++ b/src/watchtower/core.clj
@@ -108,11 +108,9 @@
 (defn extensions
   "Create a file-filter for the given extensions."
   [& exts]
-  (let [exts-set (set (map name exts))]
-    (if (contains? exts-set "*")
+  (let [exts-set (set (map #(str "." (name %)) exts))]
+    (if (exts-set ".*")
       (constantly true)
-      (fn [f]
-        (let [fname (.getName f)
-              idx (.lastIndexOf fname ".")
-              cur (if-not (neg? idx) (subs fname (inc idx)))]
-          (exts-set cur))))))
+      (fn [file]
+        (let [fname (.getName file)]
+          (some #(.endsWith fname %) exts-set))))))

--- a/src/watchtower/core.clj
+++ b/src/watchtower/core.clj
@@ -4,30 +4,30 @@
 (def ^{:dynamic true} *last-pass* nil)
 
 ;;*****************************************************
-;; Watcher map creation 
+;; Watcher map creation
 ;;*****************************************************
 
-(defn watcher* 
+(defn watcher*
   "Create a watcher map that can later be passed to (watch)"
   [dirs]
   (let [dirs (if (string? dirs)
                [dirs]
-               dirs)]  
+               dirs)]
     {:dirs dirs
      :filters []}))
 
-(defn file-filter 
+(defn file-filter
   "Add a filter to a watcher. A filter is just a function that takes in a
   java.io.File and returns truthy about whether or not it should be included."
   [w filt]
   (update-in w [:filters] conj filt))
 
-(defn rate 
+(defn rate
   "Set the rate of polling."
   [w r]
   (assoc w :rate r))
 
-(defn on-change 
+(defn on-change
   "When files are changed, execute a function that takes in a seq of the changed
   file objects."
   [w func]
@@ -39,10 +39,10 @@
   (assoc w :change-first? bool))
 
 ;;*****************************************************
-;; Watcher execution  
+;; Watcher execution
 ;;*****************************************************
 
-(defn default-filter [f] 
+(defn default-filter [f]
   (.isFile f))
 
 (defn modified? [f]
@@ -58,7 +58,7 @@
     (fn []
       (let [files (get-files dirs final-filter)
             results (seq (doall (filter modified? files)))]
-        (when results 
+        (when results
           (reset! *last-pass* (System/currentTimeMillis)))
         results))))
 
@@ -82,10 +82,10 @@
     (binding [*last-pass* (atom pass)]
       (while true
         (Thread/sleep rate)
-        (when-let [changes (updated?)] 
+        (when-let [changes (updated?)]
           (changed changes))))))
 
-(defmacro watcher 
+(defmacro watcher
   "Create a watcher for the given dirs (either a string or coll of strings), applying
   the given transformations.
 
@@ -100,12 +100,12 @@
 ;; file filters
 ;;*****************************************************
 
-(defn ignore-dotfiles 
+(defn ignore-dotfiles
   "A file-filter that removes any file that starts with a dot."
   [f]
   (not= \. (first (.getName f))))
 
-(defn extensions 
+(defn extensions
   "Create a file-filter for the given extensions."
   [& exts]
   (let [exts-set (set (map name exts))]

--- a/src/watchtower/core.clj
+++ b/src/watchtower/core.clj
@@ -109,8 +109,10 @@
   "Create a file-filter for the given extensions."
   [& exts]
   (let [exts-set (set (map name exts))]
-    (fn [f]
-      (let [fname (.getName f)
-            idx (.lastIndexOf fname ".")
-            cur (if-not (neg? idx) (subs fname (inc idx)))]
-        (exts-set cur)))))
+    (if (contains? exts-set "*")
+      (constantly true)
+      (fn [f]
+        (let [fname (.getName f)
+              idx (.lastIndexOf fname ".")
+              cur (if-not (neg? idx) (subs fname (inc idx)))]
+          (exts-set cur))))))

--- a/test/watchtower/test/core.clj
+++ b/test/watchtower/test/core.clj
@@ -5,17 +5,14 @@
   (:require
     [clojure.java.io :as io]))
 
-;(deftest replace-me ;; FIXME: write
-;  (is false "No tests have been written."))
-
+;; extensions
 (deftest extensions-test
   (testing "single extension"
     (let [f #((extensions :clj) (io/file %))]
       (is (f "foo.clj"))
       (is (not (f "fooclj")))
       (is (not (f "foo.txt")))
-      (is (not (f "footxt")))
-      ))
+      (is (not (f "footxt")))))
 
   (testing "multi extensions"
     (let [f #((extensions :clj :txt) (io/file %))]
@@ -38,10 +35,9 @@
       (is (f "foo.txt"))
       (is (f "footxt"))))
 
-  ;(testing "doubled extensions"
-  ;  (let [f #((extensions :* :html.clj) (io/file %))]
-  ;    (is (f "foo.html.clj"))
-  ;    (is (not (f "foohtml.clj")))
-  ;    (is (not (f "foo.clj")))
-  ;    (is (not (f "foo.html")))))
-  )
+  (testing "doubled extensions"
+    (let [f #((extensions :html.clj) (io/file %))]
+      (is (f "foo.html.clj"))
+      (is (not (f "foohtml.clj")))
+      (is (not (f "foo.clj")))
+      (is (not (f "foo.html"))))))

--- a/test/watchtower/test/core.clj
+++ b/test/watchtower/test/core.clj
@@ -1,6 +1,47 @@
 (ns watchtower.test.core
-  (:use [watchtower.core])
-  (:use [clojure.test]))
+  (:use
+    watchtower.core
+    clojure.test)
+  (:require
+    [clojure.java.io :as io]))
 
-(deftest replace-me ;; FIXME: write
-  (is false "No tests have been written."))
+;(deftest replace-me ;; FIXME: write
+;  (is false "No tests have been written."))
+
+(deftest extensions-test
+  (testing "single extension"
+    (let [f #((extensions :clj) (io/file %))]
+      (is (f "foo.clj"))
+      (is (not (f "fooclj")))
+      (is (not (f "foo.txt")))
+      (is (not (f "footxt")))
+      ))
+
+  (testing "multi extensions"
+    (let [f #((extensions :clj :txt) (io/file %))]
+      (is (f "foo.clj"))
+      (is (not (f "fooclj")))
+      (is (f "foo.txt"))
+      (is (not (f "footxt")))))
+
+  (testing "wildcard"
+    (let [f #((extensions :*) (io/file %))]
+      (is (f "foo.clj"))
+      (is (f "fooclj"))
+      (is (f "foo.txt"))
+      (is (f "footxt"))))
+
+  (testing "wildcard and extension"
+    (let [f #((extensions :* :clj) (io/file %))]
+      (is (f "foo.clj"))
+      (is (f "fooclj"))
+      (is (f "foo.txt"))
+      (is (f "footxt"))))
+
+  ;(testing "doubled extensions"
+  ;  (let [f #((extensions :* :html.clj) (io/file %))]
+  ;    (is (f "foo.html.clj"))
+  ;    (is (not (f "foohtml.clj")))
+  ;    (is (not (f "foo.clj")))
+  ;    (is (not (f "foo.html")))))
+  )


### PR DESCRIPTION
I added `change-first?` function.
This function set whether `on-chnage` function will be execute at startup or not.

At startup, watchtower execute `on-change` function for all files one by one,
and if there are many files, this behavior will cause slow startup.
